### PR TITLE
explicitly referencing emscripten::index (fixing reference to 'index'…

### DIFF
--- a/opencv/modules/js/src/core_bindings.cpp
+++ b/opencv/modules/js/src/core_bindings.cpp
@@ -482,10 +482,10 @@ EMSCRIPTEN_BINDINGS(binding_utils)
     function("rotatedRectBoundingRect2f", select_overload<Rect2f(const cv::RotatedRect&)>(&binding_utils::rotatedRectBoundingRect2f));
 
     emscripten::value_array<cv::Scalar_<double>> ("Scalar")
-        .element(index<0>())
-        .element(index<1>())
-        .element(index<2>())
-        .element(index<3>());
+        .element(emscripten::index<0>())
+        .element(emscripten::index<1>())
+        .element(emscripten::index<2>())
+        .element(emscripten::index<3>());
 
     emscripten::value_object<binding_utils::MinMaxLoc>("MinMaxLoc")
         .field("minVal", &binding_utils::MinMaxLoc::minVal)


### PR DESCRIPTION
Thanks for sharing this repo: it's useful to learn from !

I ran into a few compiler errors mentioning `reference to 'index' is ambiguous`.

This is a minimal patch addressing the errors. 

Hope this is ok to to contribute, otherwise happy to incorporate your feedback.

Many thanks,
George